### PR TITLE
Update repository URL and directory name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Doze-Studio-Practise/
 
 1. **Clone the repository**
    ```bash
-   git clone [repository-url]
-   cd Doze-Studio-Practise
+   git clone https://github.com/prashantkoirala465/Interactive-Hero-Canvas-Animation
+   cd Interactive-Hero-Canvas-Animation
    ```
 
 2. **Open in browser**


### PR DESCRIPTION
This pull request updates the repository setup instructions in the `README.md` file to reference the correct GitHub repository URL and directory name. This ensures that users clone and navigate to the intended project.

- Documentation update:
  * Updated the clone command and directory path in the setup instructions to use `Interactive-Hero-Canvas-Animation` instead of the previous placeholder values.